### PR TITLE
Current playback status script

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+ 
+status=` dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | tail -1 | cut -d "\"" -f2`
+echo $status


### PR DESCRIPTION
Hi there,

I added a little script for getting the status -paused, playing...- of the current song.

Usage: `${exec ~/.conky/conky-spotify/scripts/status.sh}`
