### PR TITLE
display album correcty even if it contains "album"

### DIFF
--- a/scripts/album.sh
+++ b/scripts/album.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
  
-album=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|egrep -A 1 "album"|egrep -v "album"|cut -b 44-|cut -d '"' -f 1|egrep -v ^$`
+album=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|egrep -A 1 "album"| egrep -A 1 "album" | egrep "^\s*variant" | cut -b 44- | egrep -v ^$ | sed 's/"$//'`
 echo $album


### PR DESCRIPTION
cases were the albums name contained the "album" were not displayed correctly.
this version can even handle double braces in the albums name.