### PR TITLE
allow maximum_width modifications

### DIFF
--- a/conky-spotify-medium
+++ b/conky-spotify-medium
@@ -50,5 +50,6 @@ ${goto 132}${font GE Inspira:size=14}${exec ~/.conky/conky-spotify/scripts/artis
 ${voffset -32}
 ${goto 124}${font Noto Sans:size=7}Album:
 ${goto 132}${font GE Inspira:size=14}${exec ~/.conky/conky-spotify/scripts/album.sh}
+${voffset -32}
 ]];
 


### PR DESCRIPTION
${voffset -32} was added to the end of conky.text so that long album names are displayed fully.
Just change the maximum_width to a larger number if this is the case.