### PR TITLE
Fix img_url not working

### DIFF
--- a/scripts/imgurl.sh
+++ b/scripts/imgurl.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-imgurl=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' | egrep -A 1 "artUrl" | egrep -v "artUrl"| cut -b 44- | cut -d '"' -f 1`
+trackid=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' | egrep -A 1 "trackid" | egrep -v "trackid"| cut -b 44- | cut -d '"' -f 1`
+#echo $trackid
+oembed_url="https://open.spotify.com/oembed?url=$trackid"
+#echo $oembed_url
+imgurl=`curl -s $oembed_url | jq '.thumbnail_url' | tr -d '"'`
 echo $imgurl

--- a/scripts/imgurl.sh
+++ b/scripts/imgurl.sh
@@ -4,5 +4,5 @@ trackid=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpri
 #echo $trackid
 oembed_url="https://open.spotify.com/oembed?url=$trackid"
 #echo $oembed_url
-imgurl=`curl -s $oembed_url | jq '.thumbnail_url' | tr -d '"'`
+imgurl=`curl -s $oembed_url | grep -o -E "\"thumbnail_url\":\"http[^\"]+\"" | sed 's/\:/\n/' | tail -n 1 | tr -d '"'`
 echo $imgurl


### PR DESCRIPTION
Switched img_url code to fetch thumbnail_url from their oEmbed API using the trackid field. This could very well just be fixed by changing the hostname for img_url to `https://i.scdn.co/image/` as mentioned in issue #7, but using the api ensure more safety in case spotify decides to host their files on a different hostname.