### PR TITLE
replace egrep with grep -E

### DIFF
--- a/scripts/album.sh
+++ b/scripts/album.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
  
-album=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|egrep -A 1 "album"|egrep "^\s*variant"|cut -b 44-|egrep -v ^$|sed 's/"$//'`
+album=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 1 "album"|grep -E "^\s*variant"|cut -b 44-|grep -E -v ^$|sed 's/"$//'`
 echo $album

--- a/scripts/artist.sh
+++ b/scripts/artist.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
  
-artist=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|egrep -A 2 "artist"|egrep -v "artist"|egrep -v "array"|cut -b 27-|cut -d '"' -f 1|egrep -v ^$`
+artist=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 2 "artist"|grep -E -v "artist"|grep -E -v "array"|cut -b 27-|cut -d '"' -f 1|grep -E -v ^$`
 echo $artist

--- a/scripts/imgurl.sh
+++ b/scripts/imgurl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-trackid=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' | egrep -A 1 "trackid" | egrep -v "trackid"| cut -b 44- | cut -d '"' -f 1`
+trackid=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' | grep -E -A 1 "trackid" | grep -E -v "trackid"| cut -b 44- | cut -d '"' -f 1`
 #echo $trackid
 oembed_url="https://open.spotify.com/oembed?url=$trackid"
 #echo $oembed_url

--- a/scripts/title.sh
+++ b/scripts/title.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-title=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|egrep -A 1 "title"|egrep -v "title"|cut -b 44-|cut -d '"' -f 1|egrep -v ^$`
+title=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 1 "title"|grep -E -v "title"|cut -b 44-|cut -d '"' -f 1|grep -E -v ^$`
 echo $title


### PR DESCRIPTION
The egrep and fgrep commands have been deprecated since grep 2.5.3 (in 2007). Since the last release (3.8), they print a warning that grep -E and grep -F should be used instead.

See https://savannah.gnu.org/forum/forum.php?forum_id=10227